### PR TITLE
Updated "Names for headings" main.typ

### DIFF
--- a/template/main.typ
+++ b/template/main.typ
@@ -93,9 +93,9 @@
 
 // Names for headings
 #set heading(supplement: it => {
-  if (it.has("level")) {
-    if it.level == 1 [Part]
-    else if it.level == 2 [Chapter]
+  if (it.has("depth")) {
+    if it.depth == 1 [Part]
+    else if it.depth == 2 [Chapter]
     else [Section]
   } else {
     [ERROR, this should not happen]


### PR DESCRIPTION
Error was given with "level", when referencing headers. Fixed by relying on "depth" instead.